### PR TITLE
Update tooltip.lua for 10.2.5 Archivist currency

### DIFF
--- a/ElvUI_LocPlus/tooltip.lua
+++ b/ElvUI_LocPlus/tooltip.lua
@@ -122,6 +122,7 @@ local currency = {
 	2707,	-- Drake's Dreaming Crest
 	2708,	-- Wyrm's Dreaming Crest
 	2709,	-- Aspect's Dreaming Crest
+	2657,	-- Mysterious Fragment
 }
 
 --[[if E.myfaction == 'Alliance' then


### PR DESCRIPTION
Update to include the new archivist's event currency (used for mounts and transmog).